### PR TITLE
Addition of a cropmark editor to the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Before using this option, CutStudio must be set up so that normal use works prop
 
 1. Open Inkscape, create a new blank file.
 2. Open the Extensions menu, then select Roland CutStudio -> Insert Cropmarks.
-3. ~~You now have an example file with DIN A4 pagesize and crop marks that should work on a Roland GX-24 (and hopefully many other plotters). Changing the page size and cropmark position is currently not possible.~~
-    You can edit the example file by Extensions -> Roland CutStudio -> Roland Cropmark Editor.
+3. You now have an example file with DIN A4 pagesize and crop marks that should work on a Roland GX-24 (and hopefully many other plotters). You can change the page size and cropmark position with Extensions -> Roland CutStudio -> Roland Cropmark Editor.
 4. Choose your margin preferance, paper size and the type of cropmarks to use (three or four).  
 6. The following explanation uses separate layers for printing and drawing. You can also do it in a different way.
 7. Draw your print graphics on the layer "Print graphics". Remove the "Remove me" placeholder.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Before using this option, CutStudio must be set up so that normal use works prop
 1. Open Inkscape, create a new blank file.
 2. Open the Extensions menu, then select Roland CutStudio -> Insert Cropmarks.
 3. ~~You now have an example file with DIN A4 pagesize and crop marks that should work on a Roland GX-24 (and hopefully many other plotters). Changing the page size and cropmark position is currently not possible.~~
-    You can edit the example file by Extensions -> Roland CutStudio -> Roland Cropmark Editor (tested only with Roland CutStudio installed).
+    You can edit the example file by Extensions -> Roland CutStudio -> Roland Cropmark Editor.
 4. Choose your machine and paper size
 5. The following explanation uses separate layers for printing and drawing. You can also do it in a different way.
 6. Draw your print graphics on the layer "Print graphics". Remove the "Remove me" placeholder.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Before using this option, CutStudio must be set up so that normal use works prop
 2. Open the Extensions menu, then select Roland CutStudio -> Insert Cropmarks.
 3. ~~You now have an example file with DIN A4 pagesize and crop marks that should work on a Roland GX-24 (and hopefully many other plotters). Changing the page size and cropmark position is currently not possible.~~
     You can edit the example file by Extensions -> Roland CutStudio -> Roland Cropmark Editor.
-4. Choose your machine and paper size
-5. The following explanation uses separate layers for printing and drawing. You can also do it in a different way.
-6. Draw your print graphics on the layer "Print graphics". Remove the "Remove me" placeholder.
+4. Choose your margin preferance, paper size and the type of cropmarks to use (three or four).  
+6. The following explanation uses separate layers for printing and drawing. You can also do it in a different way.
+7. Draw your print graphics on the layer "Print graphics". Remove the "Remove me" placeholder.
 5. Copy/draw your cut lines on the layer "Cut lines".
 6. Hide the helper layer once you are finished designing.
 7. Hide the layer "Cut Lines". Print the print graphics on your printer, including the black cropmark circles.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Follow the steps above. Once the plugin has completed the export, you'll see a d
     2. To install system-wide: open the same preferences tab. The correct folder is listed further down under 'Inkscape extensions'.
 3. Restart Inkscape.
 
-[zip]: https://github.com/mgmax/inkscape-roland-cutstudio/archive/refs/heads/master.zip
+[zip]: https://github.com/dodomarg/inkscape-roland-cutstudio/archive/refs/heads/master.zip
 
 ### Installation notes
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ Before using this option, CutStudio must be set up so that normal use works prop
 
 1. Open Inkscape, create a new blank file.
 2. Open the Extensions menu, then select Roland CutStudio -> Insert Cropmarks.
-3. You now have an example file with DIN A4 pagesize and crop marks that should work on a Roland GX-24 (and hopefully many other plotters). Changing the page size and cropmark position is currently not possible.
-4. The following explanation uses separate layers for printing and drawing. You can also do it in a different way.
-5. Draw your print graphics on the layer "Print graphics". Remove the "Remove me" placeholder.
+3. ~~You now have an example file with DIN A4 pagesize and crop marks that should work on a Roland GX-24 (and hopefully many other plotters). Changing the page size and cropmark position is currently not possible.~~
+    You can edit the example file by Extensions -> Roland CutStudio -> Roland Cropmark Editor (tested only with Roland CutStudio installed).
+4. Choose your machine and paper size
+5. The following explanation uses separate layers for printing and drawing. You can also do it in a different way.
+6. Draw your print graphics on the layer "Print graphics". Remove the "Remove me" placeholder.
 5. Copy/draw your cut lines on the layer "Cut lines".
-6. Hide the layer "Cut Lines". Print the print graphics on your printer, including the black cropmark circles.
-7. Unhide the layer "Cut lines".
-8. Select all cut lines: Click on the layer "Cut lines" in the Layers dialog. Then use "Edit - Select all".
-9. Open the Extensions menu, then select -> Roland CutStudio -> Open in CutStudio.
+6. Hide the helper layer once you are finished designing.
+7. Hide the layer "Cut Lines". Print the print graphics on your printer, including the black cropmark circles.
+8. Unhide the layer "Cut lines".
+9. Select all cut lines: Click on the layer "Cut lines" in the Layers dialog. Then use "Edit - Select all".
+10. Open the Extensions menu, then select -> Roland CutStudio -> Open in CutStudio.
 
 Now CutStudio should display your file together with gray circles for the cropmarks. Note that you must have the correct plotter selected in the CutStudio "Cut settings".
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Follow the steps above. Once the plugin has completed the export, you'll see a d
     2. To install system-wide: open the same preferences tab. The correct folder is listed further down under 'Inkscape extensions'.
 3. Restart Inkscape.
 
-[zip]: https://github.com/dodomarg/inkscape-roland-cutstudio/archive/refs/heads/master.zip
+[zip]: https://github.com/mgmax/inkscape-roland-cutstudio/archive/refs/heads/master.zip
 
 ### Installation notes
 

--- a/roland_cropmark_editor.inx
+++ b/roland_cropmark_editor.inx
@@ -4,8 +4,8 @@
   <id>org.inkscape.generate.roland_cropmark_editor</id>
 
   <param name="tab" type="notebook">
-    <page name="pos" gui-text="Settings">
-      <param name="preset" type="optiongroup" appearance="combo" gui-text="Choose the machine:">
+    <page name="settings" gui-text="Settings">
+      <param name="preset" type="optiongroup" appearance="combo" gui-text="Choose machine margins:">
         <option value="gx_24_gs_24">GX-24/GS2-24/GS-24</option>
         <option value="gr_g">GR-640/540/420, GX-640/500/400</option>
         <option value="sv_series">SV-15, SV-12</option>
@@ -22,13 +22,6 @@
         <option value="keep">Keep Existing</option>
       </param>
 
-      <param name="unit" gui-text="Unit:" type="optiongroup" appearance="combo">
-        <option translatable="no" value="mm">mm</option>
-        <option translatable="no" value="px">px</option>
-        <option translatable="no" value="pt">pt</option>
-        <option translatable="no" value="in">in</option>
-        <option translatable="no" value="cm">cm</option>
-      </param>
 
       <param name="mark_type" gui-text="Mark " type="optiongroup" appearance="combo">
         <option value="four">Four</option>
@@ -36,13 +29,44 @@
       </param>
 
       <label appearance="header">Custom Page Size (only applies when "Custom Size" is selected)</label>
-      <param name="new_width"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Width">210</param>
-      <param name="new_height"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Height">297</param>
+      <param name="new_page_unit" gui-text="Unit:" type="optiongroup" indent="10" appearance="combo">
+        <option translatable="no" value="mm">mm</option>
+        <option translatable="no" value="px">px</option>
+        <option translatable="no" value="pt">pt</option>
+        <option translatable="no" value="in">in</option>
+        <option translatable="no" value="cm">cm</option>
+      </param>
+      <param name="new_width"        type="float"  indent="5" min="0.0"  max="9999.0" precision="3" gui-text="New Page Width">210</param>
+      <param name="new_height"        type="float"  indent="5" min="0.0"  max="9999.0" precision="3" gui-text="New Page Height">297</param>
       <label appearance="header">Custom Cropmarks Margins (only applies when "Custom Margins" is selected)</label>
-      <param name="margin_top"       type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Top:">40</param>
-      <param name="margin_bottom"    type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Bottom:">20</param>
-      <param name="margin_left"      type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Left:">20</param>
-      <param name="margin_right"     type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Right:">20</param>
+      <param name="new_margins_unit" gui-text="Unit:" type="optiongroup"  indent="10" appearance="combo">
+        <option translatable="no" value="mm">mm</option>
+        <option translatable="no" value="px">px</option>
+        <option translatable="no" value="pt">pt</option>
+        <option translatable="no" value="in">in</option>
+        <option translatable="no" value="cm">cm</option>
+      </param>
+      <param name="margin_top"       type="float"  indent="5" min="0.0"  max="9999.0"  precision="3" gui-text="Top:">40</param>
+      <param name="margin_bottom"    type="float"  indent="5" min="0.0"  max="9999.0"  precision="3" gui-text="Bottom:">20</param>
+      <param name="margin_left"      type="float"  indent="5" min="0.0"  max="9999.0"  precision="3" gui-text="Left:">20</param>
+      <param name="margin_right"     type="float"  indent="5" min="0.0"  max="9999.0"  precision="3" gui-text="Right:">20</param>
+    </page>
+    <page name="about" gui-text="About">
+      <label>This extension creates and edits cropmarks for print and cut documents compatible with Roland's CutStudio software. To ensure proper functionality during print and cut operations, you must start with a custom template file as your base document. You can add this template by selecting the "Insert Cropmarks" option from the extension's menu.</label>
+      <label appearance="header">Default machine margins</label>
+      <label xml:space="preserve">The defaults are a slight compromise for simplicity:
+
+        Machine Model         | Top   | Bottom | Left  | Right 
+        --------------------- | ----- | ------ | ----- | -----
+        GX-24/GS2-24/GS-24    | 60 mm | 20 mm  | 15 mm | 15 mm
+        GR-640/540/420        | 30 mm | 45 mm  | 10 mm | 10 mm
+        GX-640/500/400        | 30 mm | 45 mm  | 10 mm | 10 mm
+        SV-15, SV-12          | 6 mm  | 30 mm  | 23 mm | 23 mm
+        SV-8                  | 6 mm  | 30 mm  | 23 mm | 23 mm
+
+      </label>
+      <label>For more information about cropmark margins visit:</label>
+      <label appearance="url">https://files.rolanddga.com/Files/CutStudioManual/CutStudio/!SSL!/Responsive_HTML5/Hints_and_Tips/crop_position.html</label>
     </page>
   </param>
 

--- a/roland_cropmark_editor.inx
+++ b/roland_cropmark_editor.inx
@@ -12,6 +12,7 @@
         <option value="sv_8">SV-8</option>
         <option value="custom">Custom Margins</option>
       </param>
+      
       <param name="page_size" type="optiongroup" appearance="combo" gui-text="Set page size to:">
         <option value="A1">A1 (594 x 841 mm)</option>
         <option value="A2">A2 (420 x 594 mm)</option>
@@ -28,6 +29,12 @@
         <option translatable="no" value="in">in</option>
         <option translatable="no" value="cm">cm</option>
       </param>
+
+      <param name="mark_type" gui-text="Mark " type="optiongroup" appearance="combo">
+        <option value="four">Four</option>
+        <option value="three">Three</option>
+      </param>
+
       <label appearance="header">Manual Page Size</label>
       <param name="new_width"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Width">210</param>
       <param name="new_height"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Height">297</param>

--- a/roland_cropmark_editor.inx
+++ b/roland_cropmark_editor.inx
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <name>Roland Cropmark Editor</name>
+  <id>org.inkscape.generate.roland_cropmark_editor</id>
+
+  <param name="tab" type="notebook">
+    <page name="pos" gui-text="Settings">
+      <param name="preset" type="optiongroup" appearance="combo" gui-text="Choose the machine:">
+        <option value="gx_24_gs_24">GX-24/GS2-24/GS-24</option>
+        <option value="gr_g">GR-640/540/420, GX-640/500/400</option>
+        <option value="sv_series">SV-15, SV-12</option>
+        <option value="sv_8">SV-8</option>
+        <option value="custom">Custom Margins</option>
+      </param>
+      <param name="page_size" type="optiongroup" appearance="combo" gui-text="Set page size to:">
+        <option value="A1">A1 (594 x 841 mm)</option>
+        <option value="A2">A2 (420 x 594 mm)</option>
+        <option value="A3">A3 (297 x 420 mm)</option>
+        <option value="A4">A4 (210 x 297 mm)</option>
+        <option value="custom">Custom Size</option>
+        <option value="keep">Keep Existing</option>
+      </param>
+
+      <param name="unit" gui-text="Unit:" type="optiongroup" appearance="combo">
+        <option translatable="no" value="mm">mm</option>
+        <option translatable="no" value="px">px</option>
+        <option translatable="no" value="pt">pt</option>
+        <option translatable="no" value="in">in</option>
+        <option translatable="no" value="cm">cm</option>
+      </param>
+      <label appearance="header">Manual Page Size</label>
+      <param name="new_width"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Width">210</param>
+      <param name="new_height"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Height">297</param>
+      <label appearance="header">Manual Cropmarks Margins</label>
+      <param name="margin_top"       type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Top:">40</param>
+      <param name="margin_bottom"    type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Bottom:">20</param>
+      <param name="margin_left"      type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Left:">20</param>
+      <param name="margin_right"     type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Right:">20</param>
+    </page>
+  </param>
+
+  <effect needs-live-preview="false">
+    <object-type>all</object-type>
+    <effects-menu>
+        <submenu _name="Roland CutStudio"/>
+    </effects-menu>
+  </effect>
+
+  <script>
+    <command location="inx" interpreter="python">roland_cropmark_editor.py</command>
+  </script>
+
+</inkscape-extension>

--- a/roland_cropmark_editor.inx
+++ b/roland_cropmark_editor.inx
@@ -35,10 +35,10 @@
         <option value="three">Three</option>
       </param>
 
-      <label appearance="header">Manual Page Size</label>
+      <label appearance="header">Custom Page Size (only applies when "Custom Size" is selected)</label>
       <param name="new_width"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Width">210</param>
       <param name="new_height"        type="float"  indent="1" min="0.0"  max="9999.0" precision="3" gui-text="New Page Height">297</param>
-      <label appearance="header">Manual Cropmarks Margins</label>
+      <label appearance="header">Custom Cropmarks Margins (only applies when "Custom Margins" is selected)</label>
       <param name="margin_top"       type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Top:">40</param>
       <param name="margin_bottom"    type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Bottom:">20</param>
       <param name="margin_left"      type="float"  indent="1" min="0.0"  max="9999.0"  precision="3" gui-text="Left:">20</param>

--- a/roland_cropmark_editor.py
+++ b/roland_cropmark_editor.py
@@ -35,7 +35,8 @@ from lxml import etree
 class PrintingMarks(inkex.EffectExtension):
 
     def add_arguments(self, pars):
-        pars.add_argument("--preset", help="Apply crop marks to...", default="gx_24_gs_24")
+        pars.add_argument("--preset", help="Machine type (or 'custom' to use custom margins)", default="gx_24_gs_24")
+
         pars.add_argument("--page_size", help="Apply crop marks to...", default="A1")
         pars.add_argument("--unit", default="mm", help="Draw measurement")
         pars.add_argument("--mark_type", default="Four", help="Type of marks")

--- a/roland_cropmark_editor.py
+++ b/roland_cropmark_editor.py
@@ -36,14 +36,11 @@ class PrintingMarks(inkex.EffectExtension):
 
     def add_arguments(self, pars):
         pars.add_argument("--preset", help="Machine type (or 'custom' to use custom margins)", default="gx_24_gs_24")
-
         pars.add_argument("--page_size", help="Page size (or 'custom' to use custom new_width and new_height, or 'keep' to keep old page size)", default="A1")
-
         pars.add_argument("--unit", default="mm", help="Draw measurement")
         pars.add_argument("--mark_type", default="Four", help="Type of marks")
         pars.add_argument("--new_width", type=float, default=210.0, help="Width")
         pars.add_argument("--new_height", type=float, default=297.0, help="Height")
-        pars.add_argument("--area_inset", type=float, default=0.0, help="Cut Area Inset")
         pars.add_argument("--margin_top", type=float, default=40.0, help="Bleed Top Size")
         pars.add_argument("--margin_bottom", type=float, default=20.0, help="Bleed Bottom Size")
         pars.add_argument("--margin_left", type=float, default=20.0, help="Bleed Left Size")
@@ -226,9 +223,7 @@ class PrintingMarks(inkex.EffectExtension):
         # Call the draw_hairline_rectangle function to add the rectangle to the layer
         self.draw_hairline_rectangle(layer, x, y, width, height)
 
-    def add_cropmark_settings_text(
-        self, pageW, pageH, dx, dy, W, H, x, y, parent
-        ):
+    def add_cropmark_settings_text(self, pageW, pageH, dx, dy, W, H, x, y, parent):
             """
             Adds a text object to the given parent with crop mark settings.
 
@@ -294,9 +289,6 @@ class PrintingMarks(inkex.EffectExtension):
         layer.set("sodipodi:insensitive", "true")
         
         # Convert parameters to user unit
-        offset = self.svg.viewport_to_unit(
-            str(self.options.area_inset) + self.options.unit
-        )
         margin_top = self.svg.viewport_to_unit(str(self.options.margin_top) + self.options.unit)
         margin_bottom = self.svg.viewport_to_unit(str(self.options.margin_bottom) + self.options.unit)
         margin_left = self.svg.viewport_to_unit(str(self.options.margin_left) + self.options.unit) 

--- a/roland_cropmark_editor.py
+++ b/roland_cropmark_editor.py
@@ -307,14 +307,14 @@ class PrintingMarks(inkex.EffectExtension):
 
         if self.options.mark_type == "three":
             # Center lines for cropmarks
-            offset_left = bbox.left + margin_left + 5
+            offset_left = bbox.left + margin_left + 5 
             offset_right = bbox.right - margin_right - 5 
             offset_top = bbox.top + margin_top + 5
             offset_bottom = bbox.bottom - margin_bottom - 5
             
-            # CutStudio uses cardinal coordinates for positioning the cropmarks
+            # CutStudio uses uses bottom left origin 
             dx = offset_left
-            dy = offset_left
+            dy = bbox.bottom - offset_bottom 
             # Spacing between the cropmarks
             width = offset_right - offset_left
             height = offset_bottom - offset_top
@@ -348,9 +348,9 @@ class PrintingMarks(inkex.EffectExtension):
             offset_top = bbox.top + margin_top + (5 + mark_size)
             offset_bottom = bbox.bottom - margin_bottom - (5 + mark_size)
             
-            # CutStudio uses cardinal coordinates for positioning the cropmarks
+            # CutStudio uses uses bottom left origin 
             dx = offset_left
-            dy = offset_left
+            dy = bbox.bottom - offset_bottom #CutStudio uses bottom left origin 
             # Spacing between the cropmarks
             width = offset_right - offset_left
             height = offset_bottom - offset_top

--- a/roland_cropmark_editor.py
+++ b/roland_cropmark_editor.py
@@ -37,7 +37,8 @@ class PrintingMarks(inkex.EffectExtension):
     def add_arguments(self, pars):
         pars.add_argument("--preset", help="Machine type (or 'custom' to use custom margins)", default="gx_24_gs_24")
 
-        pars.add_argument("--page_size", help="Apply crop marks to...", default="A1")
+        pars.add_argument("--page_size", help="Page size (or 'custom' to use custom new_width and new_height, or 'keep' to keep old page size)", default="A1")
+
         pars.add_argument("--unit", default="mm", help="Draw measurement")
         pars.add_argument("--mark_type", default="Four", help="Type of marks")
         pars.add_argument("--new_width", type=float, default=210.0, help="Width")

--- a/roland_cropmark_editor.py
+++ b/roland_cropmark_editor.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# coding=utf-8
+#
+# Authors:
+#   Nicolas Dufour - Association Inkscape-fr
+#   Aurelio A. Heckert <aurium(a)gmail.com>
+#
+# Copyright (C) 2008 Authors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+this extension automates the editing of cropmarks for the inkscape roland cutstudio extnesion
+"""
+
+import math
+import re
+import inkex
+from inkex import Circle, Rectangle, TextElement
+from lxml import etree
+
+class PrintingMarks(inkex.EffectExtension):
+
+    # TODO add tool marks for manual alingment
+
+    # TODO impemnent a way to emmbedd the custom XML from template to any file
+
+    def add_arguments(self, pars):
+        pars.add_argument("--preset", help="Apply crop marks to...", default="gx_24_gs_24")
+        pars.add_argument("--page_size", help="Apply crop marks to...", default="A1")
+        pars.add_argument("--unit", default="mm", help="Draw measurement")
+        pars.add_argument("--new_width", type=float, default=210.0, help="Width")
+        pars.add_argument("--new_height", type=float, default=297.0, help="Height")
+        pars.add_argument("--area_inset", type=float, default=0.0, help="Cut Area Inset")
+        pars.add_argument("--margin_top", type=float, default=40.0, help="Bleed Top Size")
+        pars.add_argument("--margin_bottom", type=float, default=20.0, help="Bleed Bottom Size")
+        pars.add_argument("--margin_left", type=float, default=20.0, help="Bleed Left Size")
+        pars.add_argument("--margin_right", type=float, default=20.0, help="Bleed Right Size")
+        pars.add_argument("--tab", help="The selected UI-tab when OK was pressed")
+
+    def apply_presets(self):
+        """
+        Applies page size and margin presets based on user-selected options.
+        Overrides only if the user has not selected 'custom' or 'keep' (for page size).
+        """
+        # Preset margins for machines
+        machine_margins = {
+            "gx_24_gs_24": {"top": 40.0, "bottom": 20.0, "left": 20.0, "right": 20.0},
+            "gr_g": {"top": 30.0, "bottom": 45.0, "left": 10.0, "right": 10.0},
+            "sv_series": {"top": 6.0, "bottom": 30.0, "left": 23.0, "right": 23.0},
+            "sv_8": {"top": 6.0, "bottom": 30.0, "left": 25.0, "right": 24.0},
+        }
+
+        # Page size dimensions in mm
+        page_sizes = {
+            "A1": {"width": 594.0, "height": 841.0},
+            "A2": {"width": 420.0, "height": 594.0},
+            "A3": {"width": 297.0, "height": 420.0},
+            "A4": {"width": 210.0, "height": 297.0},
+        }
+
+        # Handle page size overwrites unless "custom" is selected
+        if self.options.page_size != "custom":
+            if self.options.page_size in page_sizes:
+                page = page_sizes[self.options.page_size]
+                self.options.new_width = page["width"]
+                self.options.new_height = page["height"]
+
+        # Handle margin overwrites unless "manual" is selected
+        if self.options.preset != "custom":
+            if self.options.preset in machine_margins:
+                margins = machine_margins[self.options.preset]
+                self.options.margin_top = margins["top"]
+                self.options.margin_bottom = margins["bottom"]
+                self.options.margin_left = margins["left"]
+                self.options.margin_right = margins["right"]
+
+    def apply_resize_page(self, width, height, unit="mm"):
+        """
+        Resize the SVG page to the given width and height.
+
+        Args:
+            self: The extension object (used to access the SVG root).
+            width (float): Desired width of the page.
+            height (float): Desired height of the page.
+            unit (str): Unit for the dimensions (e.g., "mm", "px", "in"). Default is "mm".
+        """
+        # Access the SVG root element
+        root = self.document.getroot()
+
+        # Set the new page size
+        root.set("width", f"{width}{unit}")
+        root.set("height", f"{height}{unit}")
+
+        # Update the viewBox to match the new dimensions
+        root.set("viewBox", f"0 0 {width} {height}")
+
+        # Log the changes (optional for debugging purposes)
+        self.debug(f"Page resized to {width}{unit} x {height}{unit}")
+
+    def draw_reg_circile(self, x, y, name, parent):
+        """Draw a circle with 10mm diameter and black fill, no stroke, at specified position."""
+        style = {
+            "fill": "#000000",  # Black fill
+            "stroke": "none"    # No stroke
+        }
+        circle_attribs = {
+            "style": str(inkex.Style(style)),
+            inkex.addNS("label", "inkscape"): name,
+            "id": re.sub(r'\W+', '_', name),  # Replace non-alphanumeric characters with underscores
+            "cx": str(x),       # X position
+            "cy": str(y),       # Y position
+            "r": "5"            # Radius is half of the 10mm diameter
+        }
+        parent.add(inkex.elements.Circle(**circle_attribs))
+
+    def draw_hairline_rectangle(self, parent, x, y, width, height):
+        """
+        Draws a rectangle with a hairline border in gray, with a fixed ID and name.
+        Also adds a text label below the rectangle.
+
+        Args:
+            parent (inkex.BaseElement): The parent SVG element to which the rectangle will be added.
+            x (float): The x-coordinate of the rectangle's top-left corner.
+            y (float): The y-coordinate of the rectangle's top-left corner.
+            width (float): The width of the rectangle.
+            height (float): The height of the rectangle.
+        """
+        # Define the style for the rectangle
+        style = {
+            "stroke": "#808080",  # Gray color
+            "stroke-width": "0.1px",  # Hairline border
+            "fill": "none",  # No fill
+        }
+
+        # Define rectangle attributes with a fixed ID and label
+        rect_attribs = {
+            "x": str(x),
+            "y": str(y),
+            "width": str(width),
+            "height": str(height),
+            "style": str(inkex.Style(style)),
+            "id": "cutting_area",  # Fixed ID
+            inkex.addNS("label", "inkscape"): "Cutting Area",  # Fixed name for the rectangle
+        }
+
+        # Add the rectangle to the parent
+        rect = inkex.elements.Rectangle(**rect_attribs)
+        parent.add(rect)
+
+        text_style = {
+            "fill": "#808080",  # Gray color
+            "font-size": "5px",  # Font size in user units (px)
+            "text-anchor": "middle",  # Center alignment
+        }
+
+        # Define the text position (centered below the rectangle)
+        text_x = x + (width / 2)  # Center of the rectangle
+        text_y = y + height + 5   # 5mm below the bottom of the rectangle
+
+        # Create the text element
+        text_attribs = {
+            "x": str(text_x),
+            "y": str(text_y),
+            "style": str(inkex.Style(text_style)),
+            "id": "cutting_area_label",
+            inkex.addNS("label", "inkscape"): "Cutting Area Label",
+        }
+
+        text = inkex.elements.TextElement(**text_attribs)
+        text.text = "Cutting Area"
+        parent.add(text)
+
+    def add_helper_layer(self, x, y, width, height):
+        """
+        Adds a helper layer and draws a hairline rectangle on it.
+
+        Args:
+            x (float): The x-coordinate of the rectangle's top-left corner.
+            y (float): The y-coordinate of the rectangle's top-left corner.
+            width (float): The width of the rectangle.
+            height (float): The height of the rectangle.
+        """
+        svg = self.document.getroot()
+        
+        layer_id = "helper"
+        layer_name = "Helper Layer - do not print or cut"
+        
+        # Create a new layer
+        layer = svg.add(inkex.Layer.new(layer_name))
+        layer.set("id", layer_id)
+        layer.set("sodipodi:insensitive", "true")
+
+        # Call the draw_hairline_rectangle function to add the rectangle to the layer
+        self.draw_hairline_rectangle(layer, x, y, width, height)
+
+    def add_cropmark_settings_text(
+        self, pageW, pageH, dx, dy, W, H, x, y, parent
+        ):
+            """
+            Adds a text object to the given parent with crop mark settings.
+
+            Args:
+                parent (inkex.BaseElement): The parent SVG element to add the text to.
+                pageW (float): Page width in user units.
+                pageH (float): Page height in user units.
+                dx (float): Horizontal offset in user units.
+                dy (float): Vertical offset in user units.
+                W (float): Width in user units.
+                H (float): Height in user units.
+                x (float): X-coordinate for the text.
+                y (float): Y-coordinate for the text.
+                font_size (str): Font size for the text. Default is "9pt".
+            """
+            # Convert numeric values to integers to remove decimal points
+            pageW = int(pageW)
+            pageH = int(pageH)
+            dx = int(dx)
+            dy = int(dy)
+            W = int(W)
+            H = int(H)
+
+            text_style = {
+                "fill": "#000000",  
+                "font-size": "3px", 
+                "text-anchor": "middle",
+            }
+
+            txt_attribs = {
+                "x": str(x),
+                "y": str(y),
+                "style": str(inkex.Style(text_style)),
+                "id": "cropmark_settings",
+                inkex.addNS("label", "inkscape"): "Cropmark Settings",
+            }
+            txt = parent.add(inkex.TextElement(**txt_attribs))
+            
+            self.debug(txt.style)
+
+            # Construct the cropmark settings string without the extra {{
+            txt.text = (
+                f'INKSCAPE_CUTSTUDIO_CROPMARK_SETTINGS={{"version":1, '
+                f'"pageW":{pageW}, "pageH":{pageH}, '
+                f'"dx":{dx}, "dy":{dy}, '
+                f'"W":{W}, "H":{H}}}'
+            )
+
+    def draw_effect(self, bbox, name=""):
+        # Get SVG document dimensions
+        # self.width must be replaced by bbox.right. same to others.
+        svg = self.document.getroot()
+
+        # Convert parameters to user unit
+        offset = self.svg.viewport_to_unit(
+            str(self.options.area_inset) + self.options.unit
+        )
+        margin_top = self.svg.viewport_to_unit(str(self.options.margin_top) + self.options.unit)
+        margin_bottom = self.svg.viewport_to_unit(str(self.options.margin_bottom) + self.options.unit)
+        margin_left = self.svg.viewport_to_unit(str(self.options.margin_left) + self.options.unit) 
+        margin_right = self.svg.viewport_to_unit(str(self.options.margin_right) + self.options.unit)
+
+        # Center lines for cropmarks
+        offset_left = bbox.left + margin_left
+        offset_right = bbox.right - margin_right
+        offset_top = bbox.top + margin_top
+        offset_bottom = bbox.bottom - margin_bottom
+        
+        width = round(offset_right - margin_left, 0)
+        height = round(offset_bottom - margin_top, 0)
+        dx = margin_left
+        dy = margin_bottom
+
+        cutting_area_x = offset_left + 5
+        cutting_area_y = offset_top + 5
+        cutting_area_width = width - 10
+        cutting_area_heignt = height - 10
+
+        if True:
+            self.add_helper_layer(cutting_area_x, cutting_area_y, cutting_area_width, cutting_area_heignt)
+
+        # Get middle positions
+        middle_vertical = bbox.top + (bbox.height / 2)
+        middle_horizontal = bbox.left + (bbox.width / 2)
+
+        # Construct layer id and layer name
+        layer_id = "cropmarks"
+        layer_name = "Cropmarks - do not edit"
+        if name != "":
+            layer_id += "-" + name
+            layer_name += " " + name
+
+        # Create a new layer
+        layer = svg.add(inkex.Layer.new(layer_name))
+        layer.set("id", layer_id)
+        layer.set("sodipodi:insensitive", "true")
+        
+        # Cropmark Information
+        self.add_cropmark_settings_text(bbox.right, bbox.bottom, dx, dy, width, height, str(middle_horizontal), str(bbox.bottom + 20), layer)
+        self.draw_reg_circile(offset_left, offset_top, "Top Left Cropmark", layer)
+        self.draw_reg_circile(offset_left, offset_bottom, "Bottom Left Cropmark", layer)
+        self.draw_reg_circile(offset_right, offset_bottom, "Bottom Right Cropmark", layer)
+
+
+    def remove_layers(self, *layer_ids):
+        """
+        Removes layers with specified IDs from the SVG document.
+
+        Args:
+            *layer_ids: Arbitrary number of layer IDs to be removed. A maximum of 10 layers is allowed.
+
+        Raises:
+            ValueError: If more than 10 layer IDs are provided.
+        """
+        # Check if the number of layer IDs exceeds the limit
+        if len(layer_ids) > 10:
+            raise ValueError("Cannot remove more than 10 layers at once.")
+
+        # Iterate over the provided layer IDs
+        for layer_id in layer_ids:
+            # Find the layer by its ID
+            layer = self.svg.find(f".//*[@id='{layer_id}']")
+            if layer is not None:
+                # Remove the layer from the SVG document
+                self.document.getroot().remove(layer)
+
+
+
+    def effect(self):
+        # chooses if to take values from presests or user provided
+        self.apply_presets()
+
+        pages = self.svg.namedview.get_pages()
+
+        self.remove_layers("cropmarks", "helper")
+
+        # Handle single-page document
+        if len(pages) < 2:
+            if self.options.page_size != "keep":
+                self.apply_resize_page(
+                self.svg.viewport_to_unit(str(self.options.new_width) + self.options.unit), 
+                self.svg.viewport_to_unit(str(self.options.new_height) + self.options.unit),
+                self.options.unit
+                )
+            self.draw_effect(self.svg.get_page_bbox(), "")
+        else:
+            for p, page in enumerate(pages):
+                if self.options.page_size != "keep":
+                    self.apply_resize_page(
+                    self.svg.viewport_to_unit(str(self.options.new_width) + self.options.unit), 
+                    self.svg.viewport_to_unit(str(self.options.new_height) + self.options.unit),
+                    self.options.unit
+                    )
+                self.draw_effect(page.bounding_box, str(p))
+
+
+if __name__ == "__main__":
+    PrintingMarks().run()

--- a/roland_cropmark_editor.py
+++ b/roland_cropmark_editor.py
@@ -22,6 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 this extension automates the editing of cropmarks for the inkscape roland cutstudio extnesion
+based on Inkscape's printing marks extension
 """
 
 import math
@@ -105,9 +106,6 @@ class PrintingMarks(inkex.EffectExtension):
 
         # Update the viewBox to match the new dimensions
         root.set("viewBox", f"0 0 {width} {height}")
-
-        # Log the changes (optional for debugging purposes)
-        self.debug(f"Page resized to {width}{unit} x {height}{unit}")
 
     def draw_reg_circile(self, x, y, name, parent):
         """Draw a circle with 10mm diameter and black fill, no stroke, at specified position."""
@@ -246,7 +244,6 @@ class PrintingMarks(inkex.EffectExtension):
             }
             txt = parent.add(inkex.TextElement(**txt_attribs))
             
-            self.debug(txt.style)
 
             # Construct the cropmark settings string without the extra {{
             txt.text = (
@@ -311,7 +308,6 @@ class PrintingMarks(inkex.EffectExtension):
         self.draw_reg_circile(offset_left, offset_bottom, "Bottom Left Cropmark", layer)
         self.draw_reg_circile(offset_right, offset_bottom, "Bottom Right Cropmark", layer)
 
-
     def remove_layers(self, *layer_ids):
         """
         Removes layers with specified IDs from the SVG document.
@@ -334,8 +330,6 @@ class PrintingMarks(inkex.EffectExtension):
                 # Remove the layer from the SVG document
                 self.document.getroot().remove(layer)
 
-
-
     def effect(self):
         # chooses if to take values from presests or user provided
         self.apply_presets()
@@ -354,14 +348,8 @@ class PrintingMarks(inkex.EffectExtension):
                 )
             self.draw_effect(self.svg.get_page_bbox(), "")
         else:
-            for p, page in enumerate(pages):
-                if self.options.page_size != "keep":
-                    self.apply_resize_page(
-                    self.svg.viewport_to_unit(str(self.options.new_width) + self.options.unit), 
-                    self.svg.viewport_to_unit(str(self.options.new_height) + self.options.unit),
-                    self.options.unit
-                    )
-                self.draw_effect(page.bounding_box, str(p))
+            raise ValueError("Multiple pages are not supported")
+
 
 
 if __name__ == "__main__":

--- a/roland_cutstudio_cropmark_template.svg
+++ b/roland_cutstudio_cropmark_template.svg
@@ -193,7 +193,7 @@
        d="m 45.126433,111.48177 4.16947,20.81448 c -3.76828,2.08754 -6.15114,5.15135 -6.15114,8.56353 0,6.29066 8.08884,11.3896 18.061097,11.3896 9.97226,3e-5 18.05446,-5.09894 18.05446,-11.3896 0,-3.25534 -2.16793,-6.19591 -5.63911,-8.27167 l 4.23597,-21.10634 -10.10119,18.76436 c -2.03272,-0.50001 -4.23686,-0.77593 -6.55013,-0.77593 -2.12196,0 -4.16011,0.23077 -6.051397,0.6549 z"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ff0000;stroke-width:0.660499;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" /></g><g
      inkscape:groupmode="layer"
-     id="layer2"
+     id="cropmarks"
      inkscape:label="Cropmarks - do not edit"
      sodipodi:insensitive="true"><path
        d="m 70.8662,666.1416 c 0,-7.828 -6.346,-14.173 -14.173,-14.173 -7.828,0 -14.174,6.345 -14.174,14.173 0,7.828 6.346,14.173 14.174,14.173 7.827,0 14.173,-6.345 14.173,-14.173"


### PR DESCRIPTION
In order to mitigate the difficulty of changing the default template I have created a cropmark editor the takes care  of the needed changes to the document.
As TBH I did not fully understand the mechanism of the roland_cutsudio.py and was unable to edit the document to add the required data from the template to the current open document the addition is fully independent to the existing code and simply adds the ability for the user to edit the template once opened in any way they see fit. 
The addition has been tested on a Roland GS2-24 with very good user feedback. 
A behavior I was unable to understand caused the existing 3 cropmark template when sent to CutStudio to show as a four cropmark one, so for the lack of a better solution the editor offers the user 3 or 4 cropmark settings.
Test for the 3 cropmark performance were not carried out due to the issue mentioned above.  